### PR TITLE
chore(gitignore): ignore go binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,5 @@ config.local.json
 # Files containing sensitive data
 prompt.md
 prompt*.md
+
+main


### PR DESCRIPTION
# Description

This will avoid commiting the build and reduce consequently your repository size